### PR TITLE
Improvements to almost halve compile times

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,10 @@
 [target.x86_64-unknown-linux-gnu]
-linker = "/usr/bin/clang"
-rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
+linker = "clang"
+rustflags = [
+  "-Clink-arg=-fuse-ld=lld", # Use LLD Linker
+  #"-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
+  #"-Zthreads=0",             # (Nightly) Use improved multithreading with the recommended amount of threads.
+]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,26 +11,26 @@ rustflags = [
 
 # NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
 # `brew install llvm`
-[target.x86_64-apple-darwin]
-rustflags = [
-  "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
+#[target.x86_64-apple-darwin]
+#rustflags = [
+  #"-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
   #"-Zshare-generics=y",                                   # (Nightly) Make the current crate share its generic instantiations
   #"-Zthreads=0",                                          # (Nightly) Use improved multithreading with the recommended amount of threads.
-]
+#]
 
-[target.aarch64-apple-darwin]
-rustflags = [
-  "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", # Use LLD Linker
+#[target.aarch64-apple-darwin]
+#rustflags = [
+  #"-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", # Use LLD Linker
   #"-Zshare-generics=y",                                      # (Nightly) Make the current crate share its generic instantiations
   #"-Zthreads=0",                                             # (Nightly) Use improved multithreading with the recommended amount of threads.
-]
+#]
 
-[target.x86_64-pc-windows-msvc]
-linker = "rust-lld.exe" # Use LLD Linker
-rustflags = [
+#[target.x86_64-pc-windows-msvc]
+#linker = "rust-lld.exe" # Use LLD Linker
+#rustflags = [
   #"-Zshare-generics=n", # (Nightly)
   #"-Zthreads=0",        # (Nightly) Use improved multithreading with the recommended amount of threads.
-]
+#]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,36 +1,6 @@
-# NOTE: For maximum performance, build using a nightly compiler
-# If you are using rust stable, remove the "-Zshare-generics=y" below.
-
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = [
-  "-Clink-arg=-fuse-ld=lld", # Use LLD Linker
-  #"-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
-  #"-Zthreads=0",             # (Nightly) Use improved multithreading with the recommended amount of threads.
-]
-
-# NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
-# `brew install llvm`
-#[target.x86_64-apple-darwin]
-#rustflags = [
-  #"-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
-  #"-Zshare-generics=y",                                   # (Nightly) Make the current crate share its generic instantiations
-  #"-Zthreads=0",                                          # (Nightly) Use improved multithreading with the recommended amount of threads.
-#]
-
-#[target.aarch64-apple-darwin]
-#rustflags = [
-  #"-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", # Use LLD Linker
-  #"-Zshare-generics=y",                                      # (Nightly) Make the current crate share its generic instantiations
-  #"-Zthreads=0",                                             # (Nightly) Use improved multithreading with the recommended amount of threads.
-#]
-
-#[target.x86_64-pc-windows-msvc]
-#linker = "rust-lld.exe" # Use LLD Linker
-#rustflags = [
-  #"-Zshare-generics=n", # (Nightly)
-  #"-Zthreads=0",        # (Nightly) Use improved multithreading with the recommended amount of threads.
-#]
+linker = "/usr/bin/clang"
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,38 @@
+# NOTE: For maximum performance, build using a nightly compiler
+# If you are using rust stable, remove the "-Zshare-generics=y" below.
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = [
+  "-Clink-arg=-fuse-ld=lld", # Use LLD Linker
+  #"-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
+  #"-Zthreads=0",             # (Nightly) Use improved multithreading with the recommended amount of threads.
+]
+
+# NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
+# `brew install llvm`
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
+  #"-Zshare-generics=y",                                   # (Nightly) Make the current crate share its generic instantiations
+  #"-Zthreads=0",                                          # (Nightly) Use improved multithreading with the recommended amount of threads.
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", # Use LLD Linker
+  #"-Zshare-generics=y",                                      # (Nightly) Make the current crate share its generic instantiations
+  #"-Zthreads=0",                                             # (Nightly) Use improved multithreading with the recommended amount of threads.
+]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe" # Use LLD Linker
+rustflags = [
+  #"-Zshare-generics=n", # (Nightly)
+  #"-Zthreads=0",        # (Nightly) Use improved multithreading with the recommended amount of threads.
+]
+
+# Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
+# In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
+#[profile.dev]
+#debug = 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           components: clippy
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends g++ pkg-config mold clang libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends g++ pkg-config lld clang libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
       - name: Run clippy
         run: cargo clippy -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           components: clippy
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends g++ pkg-config mold clang libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
       - name: Run clippy
         run: cargo clippy -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,16 @@ include = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_os = "linux")'.dependencies]
-bevy = { version = "0.13", features = ["wayland", "x11"] }
+bevy = { version = "0.13", default-features = false, features = ["x11", "wayland", "bevy_ui", "multi-threaded", "png", "vorbis", "bevy_gizmos", "default_font",]}
 wayland-sys = "0.31"
 
 [dependencies]
-bevy = "0.13"
+bevy = { version = "0.13", default-features = false, features = ["bevy_ui", "multi-threaded", "png", "vorbis", "bevy_gizmos", "default_font",]}
 float-lerp = "0"
 rand = "0"
 rand_derive2 ="0"
 rayon = "1"
 rstest = "0"
-# bevy_iced = "0.4"
 
 [workspace]
 resolver = "2"

--- a/remove_dependencies.sh
+++ b/remove_dependencies.sh
@@ -1,19 +1,19 @@
 # Ubuntu
-sudo apt remove mold clang
-doas apt remove mold clang
+sudo apt remove lld clang
+doas apt remove lld clang
 sudo apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 
 # Fedora
 
 ## dnf5
-sudo dnf5 remove mold clang
-doas dnf5 remove mold clang
+sudo dnf5 remove lld clang
+doas dnf5 remove lld clang
 sudo dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 
 ## dnf4
-sudo dnf remove mold clang
-doas dnf remove mold clang
+sudo dnf remove lld clang
+doas dnf remove lld clang
 sudo dnf remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel

--- a/remove_dependencies.sh
+++ b/remove_dependencies.sh
@@ -1,19 +1,19 @@
 # Ubuntu
-sudo apt remove lld clang
-doas apt remove lld clang
+sudo apt remove mold clang
+doas apt remove mold clang
 sudo apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 
 # Fedora
 
 ## dnf5
-sudo dnf5 remove lld clang
-doas dnf5 remove lld clang
+sudo dnf5 remove mold clang
+doas dnf5 remove mold clang
 sudo dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 
 ## dnf4
-sudo dnf remove lld clang
-doas dnf remove lld clang
+sudo dnf remove mold clang
+doas dnf remove mold clang
 sudo dnf remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel

--- a/remove_dependencies.sh
+++ b/remove_dependencies.sh
@@ -1,9 +1,19 @@
 # Ubuntu
+sudo apt remove lld clang
+doas apt remove lld clang
 sudo apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
-sudo apt remove lld clang
 
 # Fedora
+
+## dnf5
+sudo dnf5 remove lld clang
+doas dnf5 remove lld clang
 sudo dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
+
+## dnf4
 sudo dnf remove lld clang
+doas dnf remove lld clang
+sudo dnf remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
+doas dnf remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel

--- a/remove_dependencies.sh
+++ b/remove_dependencies.sh
@@ -1,7 +1,9 @@
 # Ubuntu
 sudo apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt remove libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
+sudo apt remove lld clang
 
 # Fedora
 sudo dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 remove libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
+sudo dnf remove lld clang

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+#change to nightly for latest improvements (currently causes taffy to fail to compile)
+[toolchain]
+channel = "stable"

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -3,9 +3,11 @@ sudo apt install --fix-missing g++ pkg-config
 doas apt install --fix-missing g++ pkg-config
 sudo apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
+sudo apt-get install lld clang
 
 # Fedora
 sudo dnf install gcc-c++ 
 doas dnf install gcc-c++ 
 sudo dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
+sudo dnf install lld clang

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -1,19 +1,19 @@
 # Ubuntu
-sudo apt install --fix-missing g++ pkg-config mold clang
-doas apt install --fix-missing g++ pkg-config mold clang
+sudo apt install --fix-missing g++ pkg-config lld clang
+doas apt install --fix-missing g++ pkg-config lld clang
 sudo apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 
 # Fedora
 
 ## dnf5
-sudo dnf5 install gcc-c++ mold clang
-doas dnf5 install gcc-c++ mold clang
+sudo dnf5 install gcc-c++ lld clang
+doas dnf5 install gcc-c++ lld clang
 sudo dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 
 ## dnf4
-sudo dnf install gcc-c++ mold clang
-doas dnf install gcc-c++ mold clang
+sudo dnf install gcc-c++ lld clang
+doas dnf install gcc-c++ lld clang
 sudo dnf install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -1,19 +1,19 @@
 # Ubuntu
-sudo apt install --fix-missing g++ pkg-config lld clang
-doas apt install --fix-missing g++ pkg-config lld clang
+sudo apt install --fix-missing g++ pkg-config mold clang
+doas apt install --fix-missing g++ pkg-config mold clang
 sudo apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 
 # Fedora
 
 ## dnf5
-sudo dnf5 install gcc-c++ lld clang
-doas dnf5 install gcc-c++ lld clang
+sudo dnf5 install gcc-c++ mold clang
+doas dnf5 install gcc-c++ mold clang
 sudo dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 
 ## dnf4
-sudo dnf install gcc-c++ lld clang
-doas dnf install gcc-c++ lld clang
+sudo dnf install gcc-c++ mold clang
+doas dnf install gcc-c++ mold clang
 sudo dnf install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -1,13 +1,19 @@
 # Ubuntu
-sudo apt install --fix-missing g++ pkg-config
-doas apt install --fix-missing g++ pkg-config
+sudo apt install --fix-missing g++ pkg-config lld clang
+doas apt install --fix-missing g++ pkg-config lld clang
 sudo apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
 doas apt install --fix-missing libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 librust-alsa-sys-dev librust-libudev-sys-dev libwayland-dev libxkbcommon-dev
-sudo apt-get install lld clang
 
 # Fedora
-sudo dnf install gcc-c++ 
-doas dnf install gcc-c++ 
+
+## dnf5
+sudo dnf5 install gcc-c++ lld clang
+doas dnf5 install gcc-c++ lld clang
 sudo dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
 doas dnf5 install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
-sudo dnf install lld clang
+
+## dnf4
+sudo dnf install gcc-c++ lld clang
+doas dnf install gcc-c++ lld clang
+sudo dnf install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
+doas dnf install libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel


### PR DESCRIPTION
Bevy contains alot of default features that we dont currently need (things like hdr image support, 3D model imports ect.)
so by trimming features from bevy aswell as switching to lld linker we can reduce compile times to just over half the time it currently takes. 

From my own testing:
- current clean run: 367 deps in 1m 48s
- after feature reduction changes clean run: 332 deps in 1m 23s
- with lld linker: 332 deps in 59s

The lld linker can be installed using the following:
- Ubuntu: sudo apt-get install lld clang
- Fedora: sudo dnf install lld clang
- Arch: sudo pacman -S lld clang
